### PR TITLE
apiHostを環境変数で設定できるように変更

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,15 @@
 {
   "[typescriptreact]": {
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "[typescript]":{
-  "editor.defaultFormatter": "esbenp.prettier-vscode"
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "editor.codeActionsOnSave": {
-    }
+  "[jsonc]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "editor.codeActionsOnSave": {}
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # Kakomimasu Viewer
-Next.js製 Kakomimasu Viewer
+
+Next.js 製 Kakomimasu Viewer
+
+## 環境変数
+
+### `.env.local`
+
+| 環境変数名                   | 説明                               | デフォルト値                 |
+| ---------------------------- | ---------------------------------- | ---------------------------- |
+| `NEXT_PUBLIC_APISERVER_HOST` | API サーバのホスト名を設定します。 | `https://api.kakomimasu.com` |

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -1,7 +1,9 @@
 import ApiClient from "@kakomimasu/client-js";
 export * from "@kakomimasu/client-js";
 
-export const host: URL = new URL("https://api.kakomimasu.com");
-//export const host: URL = new URL("http://localhost:8880");
+const envApiHost =
+  process.env.NEXT_PUBLIC_APISERVER_HOST || "https://api.kakomimasu.com";
+
+export const host: URL = new URL(envApiHost);
 
 export const apiClient = new ApiClient(host);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
+    "incremental": true
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
`.env.local`ファイルに以下のように設定することでホストを変更することができます。

```
NEXT_PUBLIC_APISERVER_HOST=http://localhost:8880
```

設定しなかった時のデフォルト値は`https://api.kakomimasu.com`です。

Fix #47 