### PR TITLE
fix(env): SSR時に使用するAPIホストを別で指定できるようにしました

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Next.js 製 Kakomimasu Viewer
 
 ### `.env.local`
 
-| 環境変数名                   | 説明                               | デフォルト値                 |
-| ---------------------------- | ---------------------------------- | ---------------------------- |
-| `NEXT_PUBLIC_APISERVER_HOST` | API サーバのホスト名を設定します。 | `https://api.kakomimasu.com` |
+| 環境変数名                   | 説明                                                | デフォルト値                  |
+| ---------------------------- | --------------------------------------------------- | ----------------------------- |
+| `NEXT_PUBLIC_APISERVER_HOST` | API サーバのホスト名を設定します。                  | `https://api.kakomimasu.com`  |
+| `SSR_APISERVER_HOST`         | SSR 時に使用する API サーバのホスト名を設定します。 | `$NEXT_PUBLIC_APISERVER_HOST` |

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -1,8 +1,17 @@
 import ApiClient from "@kakomimasu/client-js";
 export * from "@kakomimasu/client-js";
 
-const envApiHost =
-  process.env.NEXT_PUBLIC_APISERVER_HOST || "https://api.kakomimasu.com";
+let envApiHost;
+
+if (typeof window !== "undefined") {
+  envApiHost =
+    process.env.SSR_APISERVER_HOST ||
+    process.env.NEXT_PUBLIC_APISERVER_HOST ||
+    "https://api.kakomimasu.com";
+} else {
+  envApiHost =
+    process.env.NEXT_PUBLIC_APISERVER_HOST || "https://api.kakomimasu.com";
+}
 
 export const host: URL = new URL(envApiHost);
 

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -13,6 +13,8 @@ if (typeof window !== "undefined") {
     process.env.NEXT_PUBLIC_APISERVER_HOST || "https://api.kakomimasu.com";
 }
 
+console.log("envApiHost", envApiHost);
+
 export const host: URL = new URL(envApiHost);
 
 export const apiClient = new ApiClient(host);


### PR DESCRIPTION
https://github.com/kakomimasu/viewer-server でviewerを実行するときに、SSR側とCSR側で使用するAPIのホストが異なる問題が発生したためこのようにしました