### PR TITLE
fix(dependabot): アップデートチェックを毎日から週一に変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,4 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
Netlifyのビルド時間を圧迫している気がしたので頻度を減らしました