### PR TITLE
refactor: `@next/next/no-document-import-in-page`ルールの除外を削除する

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -91,7 +91,6 @@ MyDocument.getInitialProps = async (ctx) => {
     <style
       data-emotion={`${style.key} ${style.ids.join(" ")}`}
       key={style.key}
-      // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: style.css }}
     />
   ));


### PR DESCRIPTION
Fixes #2