### PR TITLE
feat: issueをまとめて改良しました

### DIFF
--- a/components/gameBoard.tsx
+++ b/components/gameBoard.tsx
@@ -115,8 +115,8 @@ export default function GameBoard({
           }}
         >
           {players.map((p, pIdx) => {
-            return p.agents.map((a, aIdx) => {
-              if (a.x < 0) return <></>;
+            return p.agents.flatMap((a, aIdx) => {
+              if (a.x < 0) return [];
 
               const getAgentTransform = () => {
                 if (!board) return;
@@ -156,120 +156,118 @@ export default function GameBoard({
                 }
                 return history.reverse();
               };
+              return [
+                <Box
+                  sx={{
+                    position: "absolute",
+                    width: cellSize,
+                    height: cellSize,
+                    zIndex: 1,
 
-              return (
-                <>
+                    top,
+                    left,
+
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+
+                    transitionProperty: "top, left",
+                    transitionDuration: "0.4s",
+                  }}
+                  key={`agent-${pIdx}-${aIdx}`}
+                >
+                  <Image
+                    src={agentData.agentUrl}
+                    width={cellSize * 0.8}
+                    height={cellSize * 0.8}
+                    alt={`agent player:${pIdx} n:${aIdx}`}
+                  />
                   <Box
                     sx={{
                       position: "absolute",
-                      width: cellSize,
-                      height: cellSize,
-                      zIndex: 1,
-
-                      top,
-                      left,
-
+                      fontSize: "12px",
+                      top: "3px",
+                      left: "3px",
+                      width: "1em",
+                      height: "1em",
+                      borderRadius: "50%",
+                      backgroundColor: "yellow",
                       display: "flex",
                       alignItems: "center",
                       justifyContent: "center",
-
-                      transitionProperty: "top, left",
-                      transitionDuration: "0.4s",
+                      p: "0.5em",
                     }}
-                    key={`agent-${pIdx}-${aIdx}`}
                   >
-                    <Image
-                      src={agentData.agentUrl}
-                      width={cellSize * 0.8}
-                      height={cellSize * 0.8}
-                      alt={`agent player:${pIdx} n:${aIdx}`}
-                    />
-                    <Box
-                      sx={{
-                        position: "absolute",
-                        fontSize: "12px",
-                        top: "3px",
-                        left: "3px",
-                        width: "1em",
-                        height: "1em",
-                        borderRadius: "50%",
-                        backgroundColor: "yellow",
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                        p: "0.5em",
-                      }}
-                    >
-                      {aIdx + 1}
-                    </Box>
+                    {aIdx + 1}
                   </Box>
+                </Box>,
+                <Box
+                  key={`detail-${pIdx}-${aIdx}`}
+                  sx={{
+                    position: "absolute",
+                    width: cellSize,
+                    height: cellSize,
+                    zIndex: 3,
+
+                    top,
+                    left,
+
+                    "&:hover > *": {
+                      display: "block",
+                    },
+                  }}
+                >
                   <Box
                     sx={{
+                      // agentの詳細を表示するcss
+                      display: "none",
                       position: "absolute",
-                      width: cellSize,
-                      height: cellSize,
-                      zIndex: 3,
-
-                      top,
-                      left,
-
-                      "&:hover > *": {
-                        display: "block",
-                      },
+                      backgroundColor: "rgba(0, 0, 0, .7)",
+                      color: "white",
+                      top: "50%",
+                      left: "50%",
+                      textAlign: "center",
+                      borderRadius: "10px",
+                      p: 1,
+                      filter: "drop-shadow(0 0 5px rgba(0, 0, 0, .7))",
+                      width: "max-content",
+                      lineHeight: "1.2",
+                      border: `solid 4px ${agentData.colors[1]}`,
+                      transform: getAgentTransform(),
                     }}
                   >
+                    <span>
+                      {user ? user.screenName : userId}
+                      {" : "}
+                      {aIdx + 1}
+                    </span>
+                    <br />
+                    <span>行動履歴</span>
                     <Box
                       sx={{
-                        // agentの詳細を表示するcss
-                        display: "none",
-                        position: "absolute",
-                        backgroundColor: "rgba(0, 0, 0, .7)",
-                        color: "white",
-                        top: "50%",
-                        left: "50%",
-                        textAlign: "center",
-                        borderRadius: "10px",
-                        p: 1,
-                        filter: "drop-shadow(0 0 5px rgba(0, 0, 0, .7))",
-                        width: "max-content",
-                        lineHeight: "1.2",
-                        border: `solid 4px ${agentData.colors[1]}`,
-                        transform: getAgentTransform(),
+                        width: "13em",
+                        height: "10em",
+                        overflowY: "scroll",
                       }}
                     >
-                      <span>
-                        {user ? user.screenName : userId}
-                        {" : "}
-                        {aIdx + 1}
-                      </span>
-                      <br />
-                      <span>行動履歴</span>
-                      <Box
-                        sx={{
-                          width: "13em",
-                          height: "10em",
-                          overflowY: "scroll",
-                        }}
-                      >
-                        {agentHistory().map((e, i) => {
-                          return (
-                            <div
-                              key={i}
-                              style={{
-                                textDecoration: e.res ? "line-through" : "none",
-                              }}
-                            >
-                              T{e.turn}：
-                              {e.type !== "停留" && `x:${e.x} , y:${e.y}に`}
-                              {e.type}
-                            </div>
-                          );
-                        })}
-                      </Box>
+                      {agentHistory().map((e, i) => {
+                        return (
+                          <div
+                            key={i}
+                            style={{
+                              textDecoration: e.res ? "line-through" : "none",
+                            }}
+                          >
+                            T{e.turn}：
+                            {e.type !== "停留" && `x:${e.x} , y:${e.y}に`}
+                            {e.type}
+                          </div>
+                        );
+                      })}
                     </Box>
                   </Box>
-                </>
-              );
+                </Box>,
+              ];
             });
           })}
           {edgeCells}
@@ -294,7 +292,7 @@ export default function GameBoard({
                   return `hsl(60,100%,${l}%)`;
                 }
               };
-              const isConflict = log
+              const nConflict = log
                 ? (() => {
                     const lastActLog = log
                       .slice(-1)[0]
@@ -302,12 +300,13 @@ export default function GameBoard({
                         if (e.actions) return [...e.actions];
                         else return [];
                       });
-                    const isConflict = lastActLog?.some(
-                      (a) => a.res > 0 && a.res < 3 && a.x === x && a.y === y
-                    );
-                    return isConflict;
+                    const isConflict =
+                      lastActLog?.filter(
+                        (a) => a.res > 0 && a.res < 3 && a.x === x && a.y === y
+                      ) ?? [];
+                    return isConflict.length;
                   })()
-                : false;
+                : 0;
 
               return (
                 <Box
@@ -319,7 +318,12 @@ export default function GameBoard({
                     aspectRatio: "1",
                     backgroundColor: bgColor(),
                     outline: "1px solid #555555",
-                    animation: isConflict ? `${flash} 1s linear infinite` : "",
+                    animation:
+                      nConflict > 0
+                        ? `${flash} ${
+                            1 - (0.6 / board.nAgent) * nConflict
+                          }s linear infinite`
+                        : "",
                     height: "100%",
                     width: "100%",
                   }}

--- a/components/gameBoard.tsx
+++ b/components/gameBoard.tsx
@@ -188,12 +188,12 @@ export default function GameBoard({
       <>
         {[1, board.height + 2].map((y) => {
           return new Array(board.width).fill(0).map((_, i) => {
-            const x = i + 1;
+            const x = i;
             return (
               <Box
                 key={`index-${x}-${y}`}
                 sx={{
-                  gridColumn: x + 1,
+                  gridColumn: x + 2,
                   gridRow: y,
                   display: "flex",
                   justifyContent: "center",
@@ -208,13 +208,13 @@ export default function GameBoard({
         })}
         {[1, board.width + 2].map((x) => {
           return new Array(board.width).fill(0).map((_, i) => {
-            const y = i + 1;
+            const y = i;
             return (
               <Box
                 key={`index-${x}-${y}`}
                 sx={{
                   gridColumn: x,
-                  gridRow: y + 1,
+                  gridRow: y + 2,
                   display: "flex",
                   justifyContent: "center",
                   alignItems: "center",

--- a/components/gameBoard.tsx
+++ b/components/gameBoard.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import Image from "next/image";
-import { styled, keyframes } from "@mui/material/styles";
+import { keyframes } from "@mui/material/styles";
 import { Box } from "@mui/material";
 import { useResizeDetector } from "react-resize-detector";
 
@@ -12,6 +12,7 @@ import datas from "./player_datas";
 type Props = {
   game: Pick<Game, "board" | "tiled" | "players" | "log">;
   users: ReturnType<typeof useGameUsers>;
+  nextTiles?: { x: number; y: number }[];
 };
 
 const cellSize = 50;
@@ -22,155 +23,11 @@ const flash = keyframes({
   "50%": { backgroundColor: "#00ff00" },
 });
 
-const AgentDetailHistory = styled("div")({
-  // agent詳細内の履歴のスクロールcss
-  width: "13em",
-  height: "10em",
-  overflowY: "scroll",
-});
-
-const AgentDetail = styled("div")({
-  // agentの詳細を表示するcss
-  display: "none",
-  position: "absolute",
-  backgroundColor: "rgba(0, 0, 0, .7)",
-  color: "white",
-  zIndex: 2,
-  top: "50%",
-  left: "50%",
-  textAlign: "center",
-  borderRadius: "10px",
-  padding: "1em",
-  filter: "drop-shadow(0 0 5px rgba(0, 0, 0, .7))",
-  width: "max-content",
-  lineHeight: "1.2",
-  ".tile:hover &": {
-    display: "block",
-  },
-});
-
-type AgentProps = {
-  agent: { x: number; y: number };
-  playerIdx: number;
-  agentIdx: number;
-};
-const Agent: React.FC<AgentProps> = ({ agent, playerIdx, agentIdx }) => {
-  const isPuted = useMemo(() => agent.x !== -1, [agent.x]);
-  const top = useMemo(() => {
-    return (agent.y + 1) * cellSize + agent.y * 1;
-  }, [agent.y]);
-  const left = useMemo(() => {
-    return (agent.x + 1) * cellSize + agent.x * 1;
-  }, [agent.x]);
-  const agentData = useMemo(() => datas[playerIdx], [playerIdx]);
-
-  if (!isPuted) return <></>;
-  else
-    return (
-      <Box
-        sx={{
-          position: "absolute",
-          width: cellSize,
-          height: cellSize,
-          zIndex: 1,
-
-          top,
-          left,
-
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-
-          pointerEvents: "none",
-
-          transitionProperty: "top, left",
-          transitionDuration: "0.4s",
-        }}
-      >
-        <Image
-          src={agentData.agentUrl}
-          width={cellSize * 0.8}
-          height={cellSize * 0.8}
-          alt={`agent player:${playerIdx} n:${agentIdx}`}
-        />
-        <Box
-          sx={{
-            position: "absolute",
-            fontSize: "12px",
-            top: "3px",
-            left: "3px",
-            width: "1em",
-            height: "1em",
-            borderRadius: "50%",
-            backgroundColor: "yellow",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            p: "0.5em",
-          }}
-        >
-          {agentIdx + 1}
-        </Box>
-      </Box>
-    );
-};
-
 export default function GameBoard({
   game: { board, tiled, players, log },
   users,
+  nextTiles,
 }: Props) {
-  const isAgent = (x: number, y: number) => {
-    if (players) {
-      const agent = players
-        .map((e, i) =>
-          e.agents.map((e_, j) => {
-            return { agent: e_, player: i, n: j };
-          })
-        )
-        .flat()
-        .find((e) => e.agent.x === x && e.agent.y === y);
-      return agent;
-    } else return undefined;
-  };
-  const agentHistory = (agent: ReturnType<typeof isAgent>) => {
-    if (!agent) return [];
-    if (!log) return [];
-    const pid = agent.player,
-      aid = agent.n;
-
-    const history = [];
-    for (let i = 0; i < log.length; i++) {
-      const act = Object.assign(
-        {},
-        log[i].players[pid].actions?.find((e) => e.agentId === aid)
-      );
-      let type = "";
-      if (act) {
-        if (act.type === 1) type = "配置";
-        else if (act.type === 3) type = "移動";
-        else if (act.type === 4) type = "除去";
-        else {
-          type = "停留";
-          //act.x = act.y = undefined;
-        }
-      } else {
-        type = "停留";
-      }
-      //act.turn = i;
-      history.push({ ...act, type, turn: i });
-    }
-    return history.reverse();
-  };
-
-  const getAgentTransform = (x: number, y: number) => {
-    if (!board) return;
-    const w = board.width;
-    const h = board.height;
-    const transX = x < w / 2 ? "0%" : "-100%";
-    const transY = y < h / 2 ? "0%" : "-100%";
-    return `translate(${transX},${transY})`;
-  };
-
   const { width, height, ref } = useResizeDetector();
 
   const scale = useMemo(() => {
@@ -259,13 +116,159 @@ export default function GameBoard({
         >
           {players.map((p, pIdx) => {
             return p.agents.map((a, aIdx) => {
+              if (a.x < 0) return <></>;
+
+              const getAgentTransform = () => {
+                if (!board) return;
+                const w = board.width;
+                const h = board.height;
+                const transX = a.x < w / 2 ? "0%" : "-100%";
+                const transY = a.y < h / 2 ? "0%" : "-100%";
+                return `translate(${transX},${transY})`;
+              };
+
+              const top = (a.y + 1) * cellSize + a.y + 1;
+              const left = (a.x + 1) * cellSize + a.x + 1;
+              const agentData = datas[pIdx];
+
+              const userId = p.id;
+              const user = users.get(userId);
+              const agentHistory = () => {
+                // if (!log) return [];
+
+                const history = [];
+                for (let i = 0; i < log.length; i++) {
+                  const act = structuredClone(
+                    log[i].players[pIdx].actions?.find(
+                      (e) => e.agentId === aIdx
+                    )
+                  );
+                  let type = "";
+                  if (act) {
+                    if (act.type === 1) type = "配置";
+                    else if (act.type === 3) type = "移動";
+                    else if (act.type === 4) type = "除去";
+                    else type = "停留";
+                  } else {
+                    type = "停留";
+                  }
+                  history.push({ ...act, type, turn: i });
+                }
+                return history.reverse();
+              };
+
               return (
-                <Agent
-                  key={`${pIdx}-${aIdx}`}
-                  agent={a}
-                  playerIdx={pIdx}
-                  agentIdx={aIdx}
-                />
+                <>
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      width: cellSize,
+                      height: cellSize,
+                      zIndex: 1,
+
+                      top,
+                      left,
+
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "center",
+
+                      transitionProperty: "top, left",
+                      transitionDuration: "0.4s",
+                    }}
+                    key={`agent-${pIdx}-${aIdx}`}
+                  >
+                    <Image
+                      src={agentData.agentUrl}
+                      width={cellSize * 0.8}
+                      height={cellSize * 0.8}
+                      alt={`agent player:${pIdx} n:${aIdx}`}
+                    />
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        fontSize: "12px",
+                        top: "3px",
+                        left: "3px",
+                        width: "1em",
+                        height: "1em",
+                        borderRadius: "50%",
+                        backgroundColor: "yellow",
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        p: "0.5em",
+                      }}
+                    >
+                      {aIdx + 1}
+                    </Box>
+                  </Box>
+                  <Box
+                    sx={{
+                      position: "absolute",
+                      width: cellSize,
+                      height: cellSize,
+                      zIndex: 3,
+
+                      top,
+                      left,
+
+                      "&:hover > *": {
+                        display: "block",
+                      },
+                    }}
+                  >
+                    <Box
+                      sx={{
+                        // agentの詳細を表示するcss
+                        display: "none",
+                        position: "absolute",
+                        backgroundColor: "rgba(0, 0, 0, .7)",
+                        color: "white",
+                        top: "50%",
+                        left: "50%",
+                        textAlign: "center",
+                        borderRadius: "10px",
+                        p: 1,
+                        filter: "drop-shadow(0 0 5px rgba(0, 0, 0, .7))",
+                        width: "max-content",
+                        lineHeight: "1.2",
+                        border: `solid 4px ${agentData.colors[1]}`,
+                        transform: getAgentTransform(),
+                      }}
+                    >
+                      <span>
+                        {user ? user.screenName : userId}
+                        {" : "}
+                        {aIdx + 1}
+                      </span>
+                      <br />
+                      <span>行動履歴</span>
+                      <Box
+                        sx={{
+                          width: "13em",
+                          height: "10em",
+                          overflowY: "scroll",
+                        }}
+                      >
+                        {agentHistory().map((e, i) => {
+                          return (
+                            <div
+                              key={i}
+                              style={{
+                                textDecoration: e.res ? "line-through" : "none",
+                              }}
+                            >
+                              T{e.turn}：
+                              {e.type !== "停留" && `x:${e.x} , y:${e.y}に`}
+                              {e.type}
+                            </div>
+                          );
+                        })}
+                      </Box>
+                    </Box>
+                  </Box>
+                </>
               );
             });
           })}
@@ -279,23 +282,9 @@ export default function GameBoard({
               // const point = board.points[i];
               const isAbs =
                 point < 0 && tile.player !== null && tile.type === 0;
-              const agent = (() => {
-                if (players) {
-                  const agent = players
-                    .map((e, i) =>
-                      e.agents.map((e_, j) => {
-                        return { agent: e_, player: i, n: j };
-                      })
-                    )
-                    .flat()
-                    .find((e) => e.agent.x === x && e.agent.y === y);
-                  return agent;
-                } else return undefined;
-              })();
+
               const bgColor = () => {
                 if (tile.player !== null) {
-                  //console.log(tile);
-                  //console.log("tile player", tile.player);
                   return datas[tile.player].colors[tile.type];
                 } else if (point < 0) {
                   const l = 100 - (Math.abs(point) * 50) / 16;
@@ -334,7 +323,6 @@ export default function GameBoard({
                     height: "100%",
                     width: "100%",
                   }}
-                  className="tile"
                 >
                   <Box
                     sx={{
@@ -354,50 +342,46 @@ export default function GameBoard({
                     </Box>
                     {isAbs && <span>{Math.abs(point)}</span>}
                   </Box>
-                  {agent &&
-                    (() => {
-                      const userId = players[agent.player].id;
-                      const user = users.get(userId);
-                      return (
-                        <AgentDetail
-                          style={{
-                            border: `solid 4px ${
-                              datas[agent.player].colors[1]
-                            }`,
-                            transform: getAgentTransform(x, y),
-                          }}
-                        >
-                          <span>
-                            {user ? user.screenName : userId}
-                            {" : "}
-                            {agent.n + 1}
-                          </span>
-                          <br />
-                          <span>行動履歴</span>
-                          <AgentDetailHistory>
-                            {agentHistory(agent).map((e, i) => {
-                              return (
-                                <div
-                                  key={i}
-                                  style={{
-                                    textDecoration:
-                                      e.res > 0 ? "line-through" : "none",
-                                  }}
-                                >
-                                  T{e.turn}：
-                                  {e.type !== "停留" && `x:${e.x} , y:${e.y}に`}
-                                  {e.type}
-                                </div>
-                              );
-                            })}
-                          </AgentDetailHistory>
-                        </AgentDetail>
-                      );
-                    })()}
                 </Box>
               );
             });
           })()}
+          {nextTiles?.map((tile, aIdx) => {
+            return (
+              <Box
+                key={`tile-${tile.x}-${tile.y}`}
+                sx={{
+                  width: cellSize,
+                  height: cellSize,
+                  gridRow: tile.y + 2,
+                  gridColumn: tile.x + 2,
+                  zIndex: 2,
+                  pointerEvents: "none",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <Box
+                  sx={{
+                    position: "relative",
+                    borderRadius: "50%",
+                    border: "1px solid",
+                    backgroundColor: "yellow",
+                    backgroundClip: "content-box",
+                    opacity: 0.8,
+                    width: "50%",
+                    height: "50%",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  {aIdx + 1}
+                </Box>
+              </Box>
+            );
+          })}
         </Box>
       )}
     </Box>

--- a/components/gamePanel.tsx
+++ b/components/gamePanel.tsx
@@ -14,10 +14,11 @@ import Turn from "./Turn";
 export default function GamePanel({
   game,
   users,
+  ...other
 }: {
   game: Game;
   users: ReturnType<typeof useGameUsers>;
-}) {
+} & Pick<React.ComponentProps<typeof GameBoard>, "nextTiles">) {
   const nextTurnTime = useMemo(() => {
     if (game.startedAtUnixTime) {
       const nextTurnAtUnixTime =
@@ -140,7 +141,7 @@ export default function GamePanel({
         }}
       >
         {game.board ? (
-          <GameBoard game={game} users={users} />
+          <GameBoard game={game} users={users} {...other} />
         ) : (
           <Skeleton variant="rectangular" width="inherit" height="inherit" />
         )}

--- a/components/gamePanel.tsx
+++ b/components/gamePanel.tsx
@@ -43,13 +43,17 @@ export default function GamePanel({
     <Box
       sx={{
         display: "grid",
+        maxHeight: {
+          sm: "calc(100vh - 64px)",
+          xs: undefined,
+        },
         gridTemplateColumns: {
           sm: "minmax(auto,2fr) 1fr 1fr", // PC用
           xs: "1fr 1fr", // Mobile用
         },
         gridTemplateRows: {
           sm: "2em max-content 1fr minmax(100px,1.4fr)",
-          xs: "2em max-content 2fr 1fr max-content",
+          xs: "2em max-content minmax(max-content,2fr) minmax(max-content,1fr) max-content",
         },
         gridTemplateAreas: {
           sm: [

--- a/components/gamePanel.tsx
+++ b/components/gamePanel.tsx
@@ -132,6 +132,7 @@ export default function GamePanel({
           aspectRatio: game.board
             ? `${game.board?.width} / ${game.board?.height}`
             : "1",
+          p: 1,
         }}
       >
         {game.board ? (
@@ -141,7 +142,7 @@ export default function GamePanel({
         )}
       </Paper>
       <Paper elevation={2} sx={{ gridArea: "graph", p: 1 }}>
-        {game ? (
+        {game.board ? (
           <PointsGraph game={game} users={users} />
         ) : (
           <Skeleton variant="rectangular" width="100%" height="100%" />

--- a/components/matchTypeTab.tsx
+++ b/components/matchTypeTab.tsx
@@ -11,6 +11,7 @@ const aiList = [
   { label: "AI-5", name: "a5" },
   { label: "None", name: "none" },
 ] as const;
+type AiName = typeof aiList[number]["name"];
 
 export type MatchType =
   | {
@@ -18,7 +19,7 @@ export type MatchType =
     }
   | {
       type: "ai";
-      aiName: string;
+      aiName: AiName;
       boardName?: string;
     }
   | {
@@ -34,7 +35,7 @@ export const Component: React.FC<{
     "matchTypeTab:type",
     "free"
   );
-  const [aiName, setAiName] = useStateWithStorage<string>(
+  const [aiName, setAiName] = useStateWithStorage<AiName>(
     "matchTypeTab:aiName",
     aiList[0].name
   );

--- a/pages/game/manual.tsx
+++ b/pages/game/manual.tsx
@@ -489,6 +489,16 @@ const Page: NextPage = () => {
     []
   );
 
+  const nextTiles = useMemo(() => {
+    if (!game || !matchRes) return;
+    return axisList.map((axis, agentId) => {
+      const agent = game.players[matchRes.index].agents[agentId];
+      const x = agent.x + axis[0];
+      const y = agent.y + axis[1];
+      return { x, y };
+    });
+  }, [game, matchRes, axisList]);
+
   const participateButton = useMemo(() => {
     let disableJoin = false;
     if (matchRes) disableJoin = true;
@@ -648,9 +658,9 @@ const Page: NextPage = () => {
 
   const gamePanel = useMemo(() => {
     if (query && game) {
-      return <GamePanel game={game} users={users} />;
+      return <GamePanel game={game} users={users} nextTiles={nextTiles} />;
     } else return;
-  }, [game, users, query]);
+  }, [game, users, query, nextTiles]);
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1, m: 1 }}>


### PR DESCRIPTION
- Fix #15 
- Fix #116 
  - 手動対戦：次のターンの移動先をボード上に表示するように変更
  - 手動対戦：リロードしても前の接続を維持するように変更
- Fix #120 
- Fix #296 
- Fix #322
  - コントローラ設定をダイアログ形式に変更