### PR TITLE
🆙 recharts を 3.8.0 にアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-resize-detector": "^12.3.0",
-        "recharts": "^3.6.0",
+        "recharts": "^3.8.0",
         "redoc": "^2.5.2"
       },
       "devDependencies": {
@@ -6606,15 +6606,15 @@
       }
     },
     "node_modules/recharts": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.6.0.tgz",
-      "integrity": "sha512-L5bjxvQRAe26RlToBAziKUB7whaGKEwD3znoM6fz3DrTowCIC/FnJYnuq1GEzB8Zv2kdTfaxQfi5GoH0tBinyg==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.0.tgz",
+      "integrity": "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ==",
       "license": "MIT",
       "workspaces": [
         "www"
       ],
       "dependencies": {
-        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
         "clsx": "^2.1.1",
         "decimal.js-light": "^2.5.1",
         "es-toolkit": "^1.39.3",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-resize-detector": "^12.3.0",
-    "recharts": "^3.6.0",
+    "recharts": "^3.8.0",
     "redoc": "^2.5.2"
   },
   "devDependencies": {

--- a/pages/user/detail/[[...id]].tsx
+++ b/pages/user/detail/[[...id]].tsx
@@ -19,7 +19,7 @@ import Box from "@mui/material/Box";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import IconButton from "@mui/material/IconButton";
-import { Cell, Pie, PieChart } from "recharts";
+import { Pie, PieChart, PieSectorShapeProps, Sector } from "recharts";
 import Section, { SubSection } from "../../../components/section";
 import Content from "../../../components/content";
 import GameList from "../../../components/gamelist";
@@ -35,6 +35,8 @@ import {
 } from "../../../src/apiClient";
 import Link from "../../../src/link";
 
+const pieColors = ["#D92546", "#A7D4D9", "#F2BB9B"];
+
 const StyledContent = styled(Content)({
   display: "flex",
   alignItems: "center",
@@ -42,6 +44,9 @@ const StyledContent = styled(Content)({
 });
 
 const StyledPieChart = styled(PieChart)({ height: 300 });
+const PieShape = (props: PieSectorShapeProps) => (
+  <Sector {...props} fill={pieColors[props.index % pieColors.length]} />
+);
 const wsReq: StreamMatchesReq = {
   q: "sort:startAtUnixTime-desc type:personal",
 };
@@ -305,11 +310,8 @@ const Detail: NextPage<{}> = () => {
                       );
                     }}
                     labelLine={false}
-                  >
-                    <Cell fill="#D92546" />
-                    <Cell fill="#A7D4D9" />
-                    <Cell fill="#F2BB9B" />
-                  </Pie>
+                    shape={PieShape}
+                  ></Pie>
                 </StyledPieChart>
               </Section>
               <Section title="参加ゲーム一覧">


### PR DESCRIPTION
## 変更点

- recharts を 3.8.0 にアップデート
- Cell が非推奨になっていたので shape を使うように変更