### PR TITLE
👍 勝敗記録に凡例を表示

### DIFF
--- a/pages/user/detail/[[...id]].tsx
+++ b/pages/user/detail/[[...id]].tsx
@@ -183,6 +183,7 @@ const Detail: NextPage<{}> = () => {
     {
       name: string;
       value: number;
+      fill: string;
     }[]
   >(() => {
     const result = [0, 0, 0]; // 勝ち、負け、引き分け

--- a/pages/user/detail/[[...id]].tsx
+++ b/pages/user/detail/[[...id]].tsx
@@ -19,7 +19,7 @@ import Box from "@mui/material/Box";
 import VisibilityIcon from "@mui/icons-material/Visibility";
 import VisibilityOffIcon from "@mui/icons-material/VisibilityOff";
 import IconButton from "@mui/material/IconButton";
-import { Pie, PieChart, PieSectorShapeProps, Sector } from "recharts";
+import { Legend, Pie, PieChart } from "recharts";
 import Section, { SubSection } from "../../../components/section";
 import Content from "../../../components/content";
 import GameList from "../../../components/gamelist";
@@ -44,9 +44,6 @@ const StyledContent = styled(Content)({
 });
 
 const StyledPieChart = styled(PieChart)({ height: 300 });
-const PieShape = (props: PieSectorShapeProps) => (
-  <Sector {...props} fill={pieColors[props.index % pieColors.length]} />
-);
 const wsReq: StreamMatchesReq = {
   q: "sort:startAtUnixTime-desc type:personal",
 };
@@ -212,9 +209,9 @@ const Detail: NextPage<{}> = () => {
       });
     }
     const pieData = [
-      { name: "Win", value: result[0] },
-      { name: "Lose", value: result[1] },
-      { name: "Even", value: result[2] },
+      { name: "勝ち", value: result[0], fill: pieColors[0] },
+      { name: "負け", value: result[1], fill: pieColors[1] },
+      { name: "引き分け", value: result[2], fill: pieColors[2] },
     ];
     return pieData;
   }, [user, games]);
@@ -310,8 +307,8 @@ const Detail: NextPage<{}> = () => {
                       );
                     }}
                     labelLine={false}
-                    shape={PieShape}
-                  ></Pie>
+                  />
+                  <Legend />
                 </StyledPieChart>
               </Section>
               <Section title="参加ゲーム一覧">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * パイチャートの表示を更新：各項目の指定色で描画するように変更しました。
  * カスタム描画を廃止し、描画方式を簡素化しました。
  * ラベルを英語表記から日本語「勝ち/負け/引き分け」に切替えました。
  * 凡例（Legend）を追加して視認性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



---

ローカルで `npm run dev` を実行し、 http://localhost:3000/user/detail/kamekyame にアクセスすると、下記のように凡例が表示されていることを確認しました。

<img width="1064" height="401" alt="image" src="https://github.com/user-attachments/assets/3caa8024-d5c8-4a9f-825d-3fff0f0c32b1" />
