### PR TITLE
🆙 @netlify/plugin-nextjs を削除

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,2 @@
-[[plugins]]
-package = "@netlify/plugin-nextjs"
-
 [build]
 publish = ".next"

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "@mui/icons-material": "^6.1.0",
         "@mui/lab": "^6.0.1-beta.35",
         "@mui/material": "^6.1.0",
-        "@netlify/plugin-nextjs": "^5.15.7",
         "console-feed": "^3.8.0",
         "dayjs": "^1.11.19",
         "event-source-polyfill": "^1.0.31",
@@ -1695,15 +1694,6 @@
         "@emnapi/core": "^1.4.3",
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
-      }
-    },
-    "node_modules/@netlify/plugin-nextjs": {
-      "version": "5.15.7",
-      "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.15.7.tgz",
-      "integrity": "sha512-tSlGTwOR/dFZMrjhCxynlwc/NkOwY+bc0gurOranLtwASH5wat2WqZaPkyIdfVdNd/zNpmGxgbkH0uppg1Lsxg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/@next/env": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@mui/icons-material": "^6.1.0",
     "@mui/lab": "^6.0.1-beta.35",
     "@mui/material": "^6.1.0",
-    "@netlify/plugin-nextjs": "^5.15.7",
     "console-feed": "^3.8.0",
     "dayjs": "^1.11.19",
     "event-source-polyfill": "^1.0.31",


### PR DESCRIPTION
plugin-nextjs はNetlifyによって自動的にインストール・管理されるようになったため削除

参考：https://docs.netlify.com/build/frameworks/framework-setup-guides/nextjs/overview/#how-netlify-runs-your-nextjs-app

## 動作確認

Netlify の deploy ログで最新の `@netlify/plugin-nextjs` が使われていることを確認

> ❯ Using Next.js Runtime - v5.15.10


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Netlifyビルド設定を簡潔にしました。デプロイメント構成の不要な要素を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->