### PR TITLE
🆙 dependabotが関係あるパッケージをグループでアップデートするように変更

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"
+    groups:
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+      mui:
+        patterns:
+          - "@mui/*"


### PR DESCRIPTION
react 系や mui 系など、複数のパッケージでまとめてアップデートしたほうが良いものを dependabot で適切に PR が作られるように、設定を変更しました

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 依存関係の管理設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->