### PR TITLE
👍 初期描画時にちらつかないように修正

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -12,7 +12,6 @@ const nextConfig: NextConfig = {
         pathname: "/*",
       },
     ],
-    unoptimized: true,
   },
   experimental: {
     testProxy: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@mui/icons-material": "^6.1.0",
         "@mui/lab": "^6.0.1-beta.35",
         "@mui/material": "^6.1.0",
+        "@mui/material-nextjs": "^9.0.0",
         "console-feed": "^3.8.0",
         "dayjs": "^1.11.19",
         "event-source-polyfill": "^1.0.31",
@@ -260,9 +261,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.27.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
-      "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1536,6 +1538,41 @@
           "optional": true
         },
         "@mui/material-pigment-css": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material-nextjs": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/@mui/material-nextjs/-/material-nextjs-9.0.1.tgz",
+      "integrity": "sha512-kUPGNMOam7bZs4wgjfAEJb/hpNlWTiHcS9+1XVRsEF7I0ImvmVxvb1DMDj3hG3cfq0PggXBSwihzVJe5iFFzwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@emotion/cache": "^11.11.0",
+        "@emotion/react": "^11.11.4",
+        "@emotion/server": "^11.11.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/cache": {
+          "optional": true
+        },
+        "@emotion/server": {
           "optional": true
         },
         "@types/react": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@mui/icons-material": "^6.1.0",
     "@mui/lab": "^6.0.1-beta.35",
     "@mui/material": "^6.1.0",
+    "@mui/material-nextjs": "^9.0.0",
     "console-feed": "^3.8.0",
     "dayjs": "^1.11.19",
     "event-source-polyfill": "^1.0.31",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,29 +6,20 @@ import Snackbar from "@mui/material/Snackbar";
 import Alert from "@mui/material/Alert";
 import AlertTitle from "@mui/material/AlertTitle";
 import { ThemeProvider, styled } from "@mui/material/styles";
-import { CacheProvider, EmotionCache } from "@emotion/react";
+import { AppCacheProvider } from "@mui/material-nextjs/v16-pagesRouter";
 
 import Footer from "../components/footer";
 import Header from "../components/header";
 
 import theme from "../src/theme";
-import createEmotionCache from "../src/createEmotionCache";
 import { host } from "../src/apiClient";
 import { StateProvider } from "../src/userStore";
-
-const clientSideEmotionCache = createEmotionCache();
 
 const Main = styled("main")({
   flexGrow: 1,
 });
 
-function MyApp({
-  Component,
-  pageProps,
-  emotionCache = clientSideEmotionCache,
-}: AppProps & {
-  emotionCache?: EmotionCache;
-}) {
+function MyApp({ Component, pageProps, ...otherProps }: AppProps) {
   const [apiFailBar, setApiFailBar] = useState(false);
 
   useEffect(() => {
@@ -46,7 +37,7 @@ function MyApp({
   }, []);
 
   return (
-    <CacheProvider value={emotionCache}>
+    <AppCacheProvider {...otherProps}>
       <Head>
         <title>囲みマス</title>
         <meta
@@ -76,7 +67,7 @@ function MyApp({
           </Snackbar>
         </StateProvider>
       </ThemeProvider>
-    </CacheProvider>
+    </AppCacheProvider>
   );
 }
 export default MyApp;

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,116 +1,65 @@
-import * as React from "react";
-import Document, { Html, Head, Main, NextScript } from "next/document";
-import createEmotionServer from "@emotion/server/create-instance";
-import { CacheProvider } from "@emotion/react";
+import {
+  Html,
+  Head,
+  Main,
+  NextScript,
+  DocumentProps,
+  DocumentContext,
+} from "next/document";
 import { Box, CssBaseline } from "@mui/material";
+import {
+  DocumentHeadTags,
+  DocumentHeadTagsProps,
+  documentGetInitialProps,
+} from "@mui/material-nextjs/v16-pagesRouter";
 
 import theme from "../src/theme";
-import createEmotionCache from "../src/createEmotionCache";
 
-export default class MyDocument extends Document {
-  render() {
-    return (
-      <Html lang="ja" style={{ height: "100%" }}>
-        <Head>
-          {/* PWA primary color */}
-          <meta name="theme-color" content={theme.palette.primary.main} />
+export default function MyDocument(
+  props: DocumentProps & DocumentHeadTagsProps,
+) {
+  return (
+    <Html lang="ja" style={{ height: "100%" }}>
+      <Head>
+        {/* PWA primary color */}
+        <meta name="theme-color" content={theme.palette.primary.main} />
 
-          <link rel="icon" type="image/png" href="/img/kakomimasu-icon.png" />
-          <link rel="apple-touch-icon" href="/img/kakomimasu-icon.png" />
+        <DocumentHeadTags {...props} />
 
-          <link
-            rel="stylesheet"
-            href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
-          />
-          <link
-            rel="stylesheet"
-            href="https://fonts.googleapis.com/icon?family=Material+Icons"
-          />
-        </Head>
-        <Box
-          component="body"
-          sx={{
+        <link rel="icon" type="image/png" href="/img/kakomimasu-icon.png" />
+        <link rel="apple-touch-icon" href="/img/kakomimasu-icon.png" />
+
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap"
+        />
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/icon?family=Material+Icons"
+        />
+      </Head>
+      <Box
+        component="body"
+        sx={{
+          height: "100%",
+          "& #__next": {
             height: "100%",
-            "& #__next": {
-              height: "100%",
-              display: "flex",
-              flexDirection: "column",
-            },
-            fontFamily:
-              "Roboto,Helvetica,Noto Sans,Droid Sans,Hiragino Kaku Gothic ProN,Hiragino Sans,Meiryo,Arial Unicode MS,sans-serif",
-          }}
-        >
-          <CssBaseline />
-          <Main />
-          <NextScript />
-        </Box>
-      </Html>
-    );
-  }
+            display: "flex",
+            flexDirection: "column",
+          },
+          fontFamily:
+            "Roboto,Helvetica,Noto Sans,Droid Sans,Hiragino Kaku Gothic ProN,Hiragino Sans,Meiryo,Arial Unicode MS,sans-serif",
+        }}
+      >
+        <CssBaseline />
+        <Main />
+        <NextScript />
+      </Box>
+    </Html>
+  );
 }
 
-// `getInitialProps` belongs to `_document` (instead of `_app`),
-// it's compatible with static-site generation (SSG).
-MyDocument.getInitialProps = async (ctx) => {
-  // Resolution order
-  //
-  // On the server:
-  // 1. app.getInitialProps
-  // 2. page.getInitialProps
-  // 3. document.getInitialProps
-  // 4. app.render
-  // 5. page.render
-  // 6. document.render
-  //
-  // On the server with error:
-  // 1. document.getInitialProps
-  // 2. app.render
-  // 3. page.render
-  // 4. document.render
-  //
-  // On the client
-  // 1. app.getInitialProps
-  // 2. page.getInitialProps
-  // 3. app.render
-  // 4. page.render
-
-  const originalRenderPage = ctx.renderPage;
-
-  // You can consider sharing the same emotion cache between all the SSR requests to speed up performance.
-  // However, be aware that it can have global side effects.
-  const cache = createEmotionCache();
-  const { extractCriticalToChunks } = createEmotionServer(cache);
-
-  ctx.renderPage = () =>
-    originalRenderPage({
-      enhanceApp: (App) =>
-        function EnhanceApp(props) {
-          return (
-            <CacheProvider value={cache}>
-              <App {...props} />
-            </CacheProvider>
-          );
-        },
-    });
-
-  const initialProps = await Document.getInitialProps(ctx);
-  // This is important. It prevents emotion to render invalid HTML.
-  // See https://github.com/mui-org/material-ui/issues/26561#issuecomment-855286153
-  const emotionStyles = extractCriticalToChunks(initialProps.html);
-  const emotionStyleTags = emotionStyles.styles.map((style) => (
-    <style
-      data-emotion={`${style.key} ${style.ids.join(" ")}`}
-      key={style.key}
-      dangerouslySetInnerHTML={{ __html: style.css }}
-    />
-  ));
-
-  return {
-    ...initialProps,
-    // Styles fragment is rendered after the app and page rendering finish.
-    styles: [
-      ...React.Children.toArray(initialProps.styles),
-      ...emotionStyleTags,
-    ],
-  };
+MyDocument.getInitialProps = async (ctx: DocumentContext) => {
+  const finalProps = await documentGetInitialProps(ctx);
+  return finalProps;
 };

--- a/src/createEmotionCache.ts
+++ b/src/createEmotionCache.ts
@@ -1,5 +1,0 @@
-import createCache from "@emotion/cache";
-
-export default function createEmotionCache() {
-  return createCache({ key: "css" });
-}


### PR DESCRIPTION
自前で入れていた初期バンドルにスタイル情報を埋め込む処理がうまくいっていなかったので
mui 公式のアダプターを使うように変更

## 動作確認

- [x] プレビューページをハードリロードしてもちらつかない

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * Material-UI との統合を最新のベストプラクティスに更新しました。
  * スタイリングシステムの内部実装を最適化しました。

* **Chores**
  * Material-UI Next.js パッケージの依存関係を追加しました。
  * 画像最適化がデフォルト設定で有効になるよう変更しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kakomimasu/viewer/pull/504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->