### PR TITLE
🐛 パッケージを正常にimportできていないためにVRで試合観戦ができない不具合を修正

### DIFF
--- a/public/vr/index.html
+++ b/public/vr/index.html
@@ -40,7 +40,7 @@
 
     <script type="module">
       import { getUrlQueries, nowUnixTime, getTurnText } from "../js/util.js";
-      import ApiClient from "https://cdn.jsdelivr.net/gh/kakomimasu/client-js@main/esm/mod.js";
+      import { ApiClient } from "https://esm.sh/jsr/@kakomimasu/client-js@0.1.0";
       const apiClient = new ApiClient("https://api.kakomimasu.com");
 
       let game;


### PR DESCRIPTION
下記の手順で動作確認し、盤面が表示されることを確認しました。

1. `npm run dev` を実行
2. http://localhost:3000/vr/index.html?id=5e469b13-9f89-47a6-bc46-757ce5d8df98 にアクセス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * VRモジュールで使用する依存関係を、より安定した固定バージョンに更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->