### PR TITLE
💚 CI で使用する Node.js のバージョンに .nvmrc を参照するように修正

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -15,7 +15,7 @@ jobs:
           path: viewer
       - uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version-file: "viewer/.nvmrc"
 
       # Server setup
       - name: Clone kakomimasu/server

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: lts/*
+          node-version-file: ".nvmrc"
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## 概要

最近 Playwright の CI がタイムアウトで失敗していました。
Node.js 26 の影響で playwright のブラウザインストールがうまくいっていなかったようです。

最新の Playwright では解消されているようですが、それ以前に `.nvmrc` に記載されているサポート対象（運用環境）のバージョンと CI でのバージョンが違うことが良くなさそうだったので、いったん CI で使用する Node.js のバージョンを `.nvmrc` に揃えるように（実質的に v24.13.0 を使うように）変更しました 🙏 

## 変更点

- setup-node でバージョンに lts を指定するのではなく、.nvmrc を参照するように変更しました

## 動作確認

- [x] CI が通っている

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actions のワークフロー設定を更新し、Node.js のバージョン管理が固定値から `.nvmrc` ファイル参照に変更されました。これにより、プロジェクトで定義されたバージョンに統一されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kakomimasu/viewer/pull/510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->