### PR TITLE
👍 https://local.kakomimasu.com で起動できるようにscriptsとドキュメントを追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,38 @@ npm install
 npm run dev
 ```
 
+http://localhost:3000 にアクセスしてください。
+
+## ローカル起動（HTTPS）
+
+ログインの確認など HTTPS（`https://local.kakomimasu.com:3000`）で起動したい場合のみ、以下を実施してください。
+
+1. hosts ファイルの編集
+
+`local.kakomimasu.com` で起動するため、localhost に向けるために hosts を編集する必要があります。
+
+以下の行を hosts に追加してください。
+
+```
+127.0.0.1      local.kakomimasu.com
+```
+
+2. ローカル環境立ち上げ
+
+```
+npm run dev:https
+```
+
+3. ブラウザでアクセス
+
+https://local.kakomimasu.com:3000 にアクセスしてください
+
+> [!TIP]
+> 初回アクセス時などにブラウザで警告が出ることがありますが、「詳細設定」から「local.kakomimasu.com にアクセスする」をクリックするとページが開きます。（Google Chrome の場合）
+>
+> その後もアドレスバーに「保護されていない通信」と出ますがこのままでも開発は可能です。
+> 気になる方は、Next.js でのローカル用証明書の作成に [mkcert](https://github.com/FiloSottile/mkcert) を使用しているため、`mkcert -install` でローカルCAを登録してください
+
 ## 環境変数
 
 [Basic Features: Environment Variables | Next.js](https://nextjs-ja-translation-docs.vercel.app/docs/basic-features/environment-variables)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "npm run build:editor-util && next dev --webpack",
+    "dev:https": "npm run build:editor-util && next dev --webpack --experimental-https --hostname=local.kakomimasu.com",
     "build": "npm run build:editor-util && next build --webpack",
     "build:editor-util": "npx tsdown -c editor-util/tsdown.config.mts",
     "start": "next start",


### PR DESCRIPTION
## 概要
- ローカルHTTPS環境 (`https://local.kakomimasu.com`) で起動できるよう、実行手順と設定を追記
- 開発者向けドキュメントを更新

Fix #473 

## 変更点
- `README.md` にHTTPS開発手順を追加
- `package.json` に起動関連スクリプトを追加

## 影響範囲
- 開発環境の起動手順のみ（本番挙動への影響なし）

## 動作確認
- [x] ローカル環境でHTTPS起動手順に従って起動ができる
  - `npm run dev:https` というスクリプトを追加しました
- [x] HTTPS で起動してログイン機能が動作する