### PR TITLE
Playwright を 1.62.1 に更新

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "tsdown": "^0.20.3"
       },
       "devDependencies": {
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "^1.62.1",
         "@types/event-source-polyfill": "^1.0.5",
         "@types/node": "24.7.2",
         "@types/react": "19.2.8",
@@ -1909,19 +1909,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-      "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.57.0"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@popperjs/core": {
@@ -7327,35 +7327,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-      "integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.57.0"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.57.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-      "integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "tsdown": "^0.20.3"
   },
   "devDependencies": {
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "^1.62.1",
     "@types/event-source-polyfill": "^1.0.5",
     "@types/node": "24.7.2",
     "@types/react": "19.2.8",


### PR DESCRIPTION
## 概要
PlaywrightのテストがCIで終わらない問題があり、原因がバット分からずパッケージが古いことも関係していそうなため、パッケージを最新のものにしました。

Playwright を 1.57.0 から 1.62.1 に更新します。

## 変更内容
- `@playwright/test` を 1.62.1 に更新
- `playwright` および `playwright-core` を 1.62.1 に更新
- 依存関係ロックファイルを更新

## 動作確認

- [x] CI が通っている

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Playwrightテスト環境をバージョン1.62.1に更新しました。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->